### PR TITLE
Misc fixes to compile on Ubuntu 15.10

### DIFF
--- a/dcache.h
+++ b/dcache.h
@@ -446,7 +446,7 @@ namespace CacheSubsystem {
     }
 
     int flush_virt(Waddr virtaddr, W64 threadid) {
-      return invalidate(tagof(virtaddr, threadid));
+      return base_t::invalidate(tagof(virtaddr, threadid));
     }
   };
 

--- a/klibc.cpp
+++ b/klibc.cpp
@@ -9,6 +9,8 @@
 // GNU General Public License, Version 2.
 //
 
+// required to avoid redefinition of inline functions
+#define __NO_CTYPE
 #include <globals.h>
 #include <superstl.h>
 #include <stdarg.h>

--- a/mathlib.h
+++ b/mathlib.h
@@ -75,6 +75,7 @@ namespace math {
   }
 
   /* All floating-point numbers can be put in one of these categories.  */
+  /* FIXME: these definitions conflicts with defines in math.h
   enum {
     FP_NAN,
     FP_INFINITE,
@@ -82,6 +83,7 @@ namespace math {
     FP_SUBNORMAL,
     FP_NORMAL
   };
+  */
 
 #undef isinf
   inline int isinf(double x) {


### PR DESCRIPTION
- Fix redefinition error in ctype.h
- Fix conflicting enum in math.h
- Fix call to FullyAssociativeTagsNbitOneHot::invalidate()

Signed-off-by: Francis Giraldeau francis.giraldeau@gmail.com
